### PR TITLE
Hotfix/fixed null given license.php

### DIFF
--- a/src/JATSParser/PDF/TemplateStrategy.php
+++ b/src/JATSParser/PDF/TemplateStrategy.php
@@ -5,7 +5,7 @@ class TemplateStrategy {
     private $pdfDocument;
 
     function __construct(string $templateName, $config) {
-        $namespace = "JATSParser\\PDF\\Templates\\$templateName\\$templateName";
+        $namespace = "JATSParser\\PDF\\Templates\\$templateName\\$templateName"; //search for the class $templateName in the specified namespace 
         $this->pdfDocument = new $namespace($config);
     }
 

--- a/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/License.php
+++ b/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/License.php
@@ -4,36 +4,35 @@ use JATSParser\PDF\Templates\Renderers\Utils\TranslationsByKey;
 use JATSParser\PDF\Templates\Renderers\SingleRenderer\LinkableText;
 
 class License{
-    public static function renderLicense($pdfTemplate, Array $footerConfig, Array $translationsConfig, String $localeKey, String $licenseUrl): void {
-        if ($licenseUrl) {
-            foreach ($footerConfig['config']['licenses']['links'] as $license => $licenseLink) {
-                if ($licenseUrl === $licenseLink) {
-                    $licenseLogoPath = $footerConfig['config']['licenses']['logos'][$license]; 
-                    $pdfTemplate->Image(
-                        $licenseLogoPath, 
-                        $pdfTemplate->GetX(), 
-                        $pdfTemplate->GetY() - 1, 
-                        $footerConfig['config']['licenses']['logo_width'], 
-                        $footerConfig['config']['licenses']['logo_height'], 
-                        '', 
-                        $licenseLink, 
-                        'L'
-                    );
+    public static function renderLicense($pdfTemplate, Array $footerConfig, Array $translationsConfig, $localeKey, $licenseUrl): void {
+        foreach ($footerConfig['config']['licenses']['links'] as $license => $licenseLink) {
+            if ($licenseUrl === $licenseLink) {
+                $licenseLogoPath = $footerConfig['config']['licenses']['logos'][$license]; 
+                $pdfTemplate->Image(
+                    $licenseLogoPath, 
+                    $pdfTemplate->GetX(), 
+                    $pdfTemplate->GetY() - 1, 
+                    $footerConfig['config']['licenses']['logo_width'], 
+                    $footerConfig['config']['licenses']['logo_height'], 
+                    '', 
+                    $licenseLink, 
+                    'L'
+                );
 
-                    $xPosition = $pdfTemplate->getImageRBX() + 2;
-                    $translationText = TranslationsByKey::getTranslationByKey($translationsConfig, $localeKey, 'license_text') . ' ' . $license;
+                $xPosition = $pdfTemplate->getImageRBX() + 2;
+                $translationText = TranslationsByKey::getTranslationByKey($translationsConfig, $localeKey, 'license_text') . ' ' . $license;
 
-                    LinkableText::renderLinkableText(
-                        $pdfTemplate, 
-                        $licenseLink, 
-                        $translationText, 
-                        $xPosition, 
-                        $pdfTemplate->GetY() + 0.5, 
-                        $footerConfig['config']['licenses']['text_color'], 
-                        $footerConfig['config']['licenses']['font']
-                    );
-                }
+                LinkableText::renderLinkableText(
+                    $pdfTemplate, 
+                    $licenseLink, 
+                    $translationText, 
+                    $xPosition, 
+                    $pdfTemplate->GetY() + 0.5, 
+                    $footerConfig['config']['licenses']['text_color'], 
+                    $footerConfig['config']['licenses']['font']
+                );
             }
         }
     }
+    
 }

--- a/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/License.php
+++ b/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/License.php
@@ -3,7 +3,7 @@
 use JATSParser\PDF\Templates\Renderers\Utils\TranslationsByKey;
 use JATSParser\PDF\Templates\Renderers\SingleRenderer\LinkableText;
 
-class License{
+class License{ 
     public static function renderLicense($pdfTemplate, Array $footerConfig, Array $translationsConfig, $localeKey, $licenseUrl): void {
         foreach ($footerConfig['config']['licenses']['links'] as $license => $licenseLink) {
             if ($licenseUrl === $licenseLink) {

--- a/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/License.php
+++ b/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/License.php
@@ -17,7 +17,7 @@ class License{
                     '', 
                     $licenseLink, 
                     'L'
-                );
+                ); 
 
                 $xPosition = $pdfTemplate->getImageRBX() + 2;
                 $translationText = TranslationsByKey::getTranslationByKey($translationsConfig, $localeKey, 'license_text') . ' ' . $license;

--- a/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/LinkableText.php
+++ b/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/LinkableText.php
@@ -19,7 +19,7 @@
 */
 
 class LinkableText{
-    public static function renderLinkableText($pdfTemplate, String $url, String $visibleText, float $xPosition, float $yPosition, Array $textColor, Array $textFont, $align = '') {
+    public static function renderLinkableText($pdfTemplate, $url, $visibleText, float $xPosition, float $yPosition, Array $textColor, Array $textFont, $align = '') {
         $pdfTemplate->SetXY($xPosition, $yPosition);
         $pdfTemplate->SetTextColor($textColor[0], $textColor[1], $textColor[2]);
         $pdfTemplate->SetFont($textFont['family'], $textFont['style'], $textFont['size']);

--- a/src/JATSParser/PDF/Templates/TemplateOne/Components/Footer.php
+++ b/src/JATSParser/PDF/Templates/TemplateOne/Components/Footer.php
@@ -13,7 +13,9 @@ class Footer extends GenericComponent{
             $licenseUrl = $this->config->getLicenseUrlConfig();
                 
             $this->pdfTemplate->SetLeftMargin(25);
-            License::renderLicense($this->pdfTemplate, $footerConfig, $translationsConfig, $localeKey, $licenseUrl);
+            if ($licenseUrl) {
+                License::renderLicense($this->pdfTemplate, $footerConfig, $translationsConfig, $localeKey, $licenseUrl);
+            }
         }
 
     }


### PR DESCRIPTION
The server was giving me an error: Argument 5 passed to JATSParser\\PDF\\Templates\\Renderers\\SingleRenderer\\License::renderLicense() must be of the type string, null given.

This was resolved by checking if the variable referring to the license was not null (in the Footer of TemplateOne) before calling the renderLicense() function.