### PR TITLE
Hotfix/undefined function no clickable text error

### DIFF
--- a/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
+++ b/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
@@ -12,7 +12,7 @@ class TitlesAndSubtitles {
         unset($titlesConfig['titles_texts'][$localeKey]);
 
         $pdfTemplate->Ln(7);
-
+ 
         $pdfTemplate->SetFont($subtitlesConfig['subtitles_config']['principal_subtitle_font']['family'], $subtitlesConfig['subtitles_config']['principal_subtitle_font']['style'], $subtitlesConfig['subtitles_config']['principal_subtitle_font']['size']);
         $pdfTemplate->SetTextColor($subtitlesConfig['subtitles_config']['principal_subtitle_color'][0], $subtitlesConfig['subtitles_config']['principal_subtitle_color'][1], $subtitlesConfig['subtitles_config']['principal_subtitle_color'][2]);
         $pdfTemplate->Write(5, $subtitlesConfig['subtitles_texts'][$localeKey]);

--- a/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
+++ b/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
@@ -1,5 +1,7 @@
 <?php namespace JATSParser\PDF\Templates\Renderers\GroupRenderer;
 
+use JATSParser\PDF\Templates\Renderers\SingleRenderer\NoLinkableText;
+
 class TitlesAndSubtitles {
     public static function renderTitlesAndSubtitles($pdfTemplate, float $x, float $y, Array $titlesConfig, Array $subtitlesConfig, $localeKey) {
         $pdfTemplate->SetXY($x, $y);
@@ -20,7 +22,7 @@ class TitlesAndSubtitles {
 
         foreach ($titlesConfig['titles_texts'] as $language => $title) {
             $text = $title . '. ' . $subtitlesConfig['subtitles_texts'][$language];
-            $pdfTemplate->createNoClickableText($text, $pdfTemplate->GetX(), $pdfTemplate->GetY(), $titlesConfig['titles_config']['text_color'], $titlesConfig['titles_config']['font']);
+            NoLinkableText::renderNoLinkableText($pdfTemplate, $text, $pdfTemplate->GetX(), $pdfTemplate->GetY(), $titlesConfig['titles_config']['text_color'], $titlesConfig['titles_config']['font']);
             $pdfTemplate->Ln(3);
         }
 


### PR DESCRIPTION
The error Call to undefined method JATSParser\\PDF\\Templates\\TemplateOne\\TemplateOne::createNoClickableText() appeared because the function renderClickableText was being called on $pdfTemplate, but it no longer existed. This happened because, after the template refactoring, those specific methods of $pdfTemplate were removed and moved to the Renderers.

Therefore, the issue was resolved by calling the LinkableText Renderer and executing its renderLinkableText() function.