### PR TITLE
fix/color style in all URLs

### DIFF
--- a/src/JATSParser/PDF/PDFBodyHelper.php
+++ b/src/JATSParser/PDF/PDFBodyHelper.php
@@ -37,8 +37,6 @@ class PDFBodyHelper {
 		$modifiedHtmlString = preg_replace('/<caption>\s*/', '<br>' . '<caption>', $modifiedHtmlString);
 		$modifiedHtmlString = preg_replace('/<p class="caption">\s*/', '<p class="caption">', $modifiedHtmlString);
 
-		error_log($modifiedHtmlString);
-
 		return $modifiedHtmlString;
 	}
 	
@@ -52,7 +50,7 @@ class PDFBodyHelper {
 		foreach ($tableNodes as $tableNode) {
 			$tableNode->setAttribute('border', '1');
 			$tableNode->setAttribute('cellpadding', '2');
-			// Buscar span con clase 'label' dentro de la tabla y cambiar su contenido a 'Tabla'
+			// Search span elements with class "label" inside the table
 			$labelSpans = $xpath->evaluate('.//span[@class="label"]', $tableNode);
 			foreach ($labelSpans as $span) {
 				$spanContent = $span->textContent;


### PR DESCRIPTION
Changes were made so that styles are correctly applied to all URLs in the HTML rendered in the Body section of the template. 
There was an issue where styles weren't being applied to the URLs in the endnotes. These styles are now applied to ALL URLs.