### PR TITLE
fix: orcid logo

### DIFF
--- a/src/JATSParser/PDF/PDFConfig/Configuration.php
+++ b/src/JATSParser/PDF/PDFConfig/Configuration.php
@@ -144,6 +144,7 @@ class Configuration {
     public function getAuthorsConfig() {
         return [
             'authors_data' => $this->getMetadata('authors'),
+            'plugin_path' => $this->getMetadata('plugin_path'),
             'authors_config' => [
                 'text_color' => $this->getColorConfig('black'),
                 'fullname_font' => $this->getFontConfig('bold'),

--- a/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/AuthorsData.php
+++ b/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/AuthorsData.php
@@ -30,7 +30,7 @@ class AuthorsData {
                     
                     // ORCID CLICKABLE LOGO (before author name)
                     if (htmlspecialchars($author->getOrcid())) {
-                        ClickableOrcidLogo::renderClickableOrcidLogo($pdfTemplate, $currentX, $currentY, 5, $author->getOrcid());
+                        ClickableOrcidLogo::renderClickableOrcidLogo($pdfTemplate, $currentX, $currentY, 5, $author->getOrcid(), $authorsConfig['plugin_path']);
                         // Move position to the right of the logo for the author name
                         $pdfTemplate->SetXY($currentX + 5, $currentY); // Adjust the 5 value as needed for spacing
                     }

--- a/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/ClickableOrcidLogo.php
+++ b/src/JATSParser/PDF/Templates/Renderers/SingleRenderer/ClickableOrcidLogo.php
@@ -1,8 +1,8 @@
 <?php namespace JATSParser\PDF\Templates\Renderers\SingleRenderer;
 
 class ClickableOrcidLogo {
-    public static function renderClickableOrcidLogo($pdfTemplate, float $x, float $y, $size, $orcidLink): void {
-        $orcidLogoPath = '/var/www/html/plugins/generic/jatsParser/JATSParser/logo/orcid.png';
+    public static function renderClickableOrcidLogo($pdfTemplate, float $x, float $y, $size, $orcidLink, $pluginPath): void {
+        $orcidLogoPath = $pluginPath . '/JATSParser/logo/orcid.png';
         if (file_exists($orcidLogoPath)) {
             $pdfTemplate->Image($orcidLogoPath, $x, $y, $size, $size, '', $orcidLink);
         }


### PR DESCRIPTION
Se ha solucionado un problema relacionado con el logo del ORCID en la plantilla de PDF generada. 
El logo no se visualizaba porque se estaba queriendo acceder a una ruta incorrecta a la hora de buscarlo. Es por eso que se realizaron las modificaciones necesarias para recuperar el directorio del plugin y buscar correctamente el logo del ORCID.