### PR TITLE
TitlesAndSubtitles.php modification

### DIFF
--- a/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
+++ b/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
@@ -3,6 +3,18 @@
 use JATSParser\PDF\Templates\Renderers\SingleRenderer\NoLinkableText;
 
 class TitlesAndSubtitles {
+    /* 
+    * Renders titles and subtitles in a PDF template one after another
+    * with specific configurations for fonts and colors.
+    *
+    * @param object $pdfTemplate The PDF template object.
+    * @param float $x The x-coordinate for positioning.
+    * @param float $y The y-coordinate for positioning.
+    * @param array $titlesConfig Configuration for titles.
+    * @param array $subtitlesConfig Configuration for subtitles.
+    * @param string $localeKey The locale key for the titles and subtitles.
+    * @return void
+    */
     public static function renderTitlesAndSubtitles($pdfTemplate, float $x, float $y, Array $titlesConfig, Array $subtitlesConfig, $localeKey) {
         $pdfTemplate->SetXY($x, $y);
         
@@ -15,7 +27,7 @@ class TitlesAndSubtitles {
 
         $pdfTemplate->Ln(7);
  
-        if ($titlesConfig['titles_texts'] && $titlesConfig['titles_texts'][$localeKey]) {
+        if ($subtitlesConfig['subtitles_texts'] && $subtitlesConfig['subtitles_texts'][$localeKey]) {
             $pdfTemplate->SetFont($subtitlesConfig['subtitles_config']['principal_subtitle_font']['family'], $subtitlesConfig['subtitles_config']['principal_subtitle_font']['style'], $subtitlesConfig['subtitles_config']['principal_subtitle_font']['size']);
             $pdfTemplate->SetTextColor($subtitlesConfig['subtitles_config']['principal_subtitle_color'][0], $subtitlesConfig['subtitles_config']['principal_subtitle_color'][1], $subtitlesConfig['subtitles_config']['principal_subtitle_color'][2]);
             $pdfTemplate->Write(5, $subtitlesConfig['subtitles_texts'][$localeKey]);


### PR DESCRIPTION
Se solucionó el error que había al generar el PDF en cuanto a los subtítulos... esto ocurría porque se accedía al arreglo incorrecto para su renderizado en el PDF. En vez de acceder al arreglo $subtitlesConfig, se accedía a $titlesConfig.