### PR TITLE
add: title prefix process in TitlesAndSubtitles.php

### DIFF
--- a/src/JATSParser/PDF/PDFConfig/Configuration.php
+++ b/src/JATSParser/PDF/PDFConfig/Configuration.php
@@ -174,6 +174,18 @@ class Configuration {
         ];
     }
 
+    public function getPrefixesConfig() {
+        return [
+            'prefixes_texts' => $this->getMetadata('prefixes'),
+            'prefixes_config' => [
+                'principal_prefix_font' => $this->getFontConfig('bold', 15),
+                'principal_prefix_color' => $this->getColorConfig('accent'),
+                'text_color' => $this->getColorConfig('black'),
+                'font' => $this->getFontConfig('default', 10)
+            ]
+        ];
+    }
+
     public function getAuthorsConfig() {
         return [
             'authors_data' => $this->getMetadata('authors'),

--- a/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
+++ b/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/TitlesAndSubtitles.php
@@ -15,33 +15,111 @@ class TitlesAndSubtitles {
     * @param string $localeKey The locale key for the titles and subtitles.
     * @return void
     */
-    public static function renderTitlesAndSubtitles($pdfTemplate, float $x, float $y, Array $titlesConfig, Array $subtitlesConfig, $localeKey) {
+    public static function renderTitlesAndSubtitles($pdfTemplate, float $x, float $y, Array $titlesConfig, Array $subtitlesConfig, Array $prefixesConfig, $localeKey) {
         $pdfTemplate->SetXY($x, $y);
         
+        error_log(print_r($prefixesConfig, true));
+
+        //print principal prefix (localeKey is used to get the correct principal prefix and unset it from the array)
+        if ($prefixesConfig['prefixes_texts'] && $prefixesConfig['prefixes_texts'][$localeKey]) {
+            $pdfTemplate->SetFont(
+                $prefixesConfig['prefixes_config']['principal_prefix_font']['family'], 
+                $prefixesConfig['prefixes_config']['principal_prefix_font']['style'], 
+                $prefixesConfig['prefixes_config']['principal_prefix_font']['size']
+            );
+
+            $pdfTemplate->SetTextColor(
+                $prefixesConfig['prefixes_config']['principal_prefix_color'][0], 
+                $prefixesConfig['prefixes_config']['principal_prefix_color'][1], 
+                $prefixesConfig['prefixes_config']['principal_prefix_color'][2]
+            );
+
+            $pdfTemplate->Write(
+                5, 
+                $prefixesConfig['prefixes_texts'][$localeKey]
+            );
+            $pdfTemplate->SetX($pdfTemplate->GetX() + 1.2); // Add some space after the prefix
+
+            unset($prefixesConfig['prefixes_texts'][$localeKey]);
+        }
+
+        //print principal title (localeKey is used to get the correct principal title and unset it from the array)
         if ($titlesConfig['titles_texts'] && $titlesConfig['titles_texts'][$localeKey]) {
-            $pdfTemplate->SetFont($titlesConfig['titles_config']['principal_title_font']['family'], $titlesConfig['titles_config']['principal_title_font']['style'], $titlesConfig['titles_config']['principal_title_font']['size']);
-            $pdfTemplate->SetTextColor($titlesConfig['titles_config']['principal_title_color'][0], $titlesConfig['titles_config']['principal_title_color'][1], $titlesConfig['titles_config']['principal_title_color'][2]);
-            $pdfTemplate->Write(5, $titlesConfig['titles_texts'][$localeKey]);
+            $pdfTemplate->SetFont(
+                $titlesConfig['titles_config']['principal_title_font']['family'], 
+                $titlesConfig['titles_config']['principal_title_font']['style'], 
+                $titlesConfig['titles_config']['principal_title_font']['size']
+            );
+            
+            $pdfTemplate->SetTextColor(
+                $titlesConfig['titles_config']['principal_title_color'][0], 
+                $titlesConfig['titles_config']['principal_title_color'][1], 
+                $titlesConfig['titles_config']['principal_title_color'][2]
+            );
+
+            $pdfTemplate->Write(
+                5, 
+                $titlesConfig['titles_texts'][$localeKey]
+            );
+
             unset($titlesConfig['titles_texts'][$localeKey]);
         }
 
         $pdfTemplate->Ln(7);
  
+        //print subtitle title (localeKey is used to get the correct principal subtitle and unset it from the array)
         if ($subtitlesConfig['subtitles_texts'] && $subtitlesConfig['subtitles_texts'][$localeKey]) {
-            $pdfTemplate->SetFont($subtitlesConfig['subtitles_config']['principal_subtitle_font']['family'], $subtitlesConfig['subtitles_config']['principal_subtitle_font']['style'], $subtitlesConfig['subtitles_config']['principal_subtitle_font']['size']);
-            $pdfTemplate->SetTextColor($subtitlesConfig['subtitles_config']['principal_subtitle_color'][0], $subtitlesConfig['subtitles_config']['principal_subtitle_color'][1], $subtitlesConfig['subtitles_config']['principal_subtitle_color'][2]);
-            $pdfTemplate->Write(5, $subtitlesConfig['subtitles_texts'][$localeKey]);
+            $pdfTemplate->SetFont(
+                $subtitlesConfig['subtitles_config']['principal_subtitle_font']['family'],
+                $subtitlesConfig['subtitles_config']['principal_subtitle_font']['style'],
+                $subtitlesConfig['subtitles_config']['principal_subtitle_font']['size']
+            );
+            
+            $pdfTemplate->SetTextColor(
+                $subtitlesConfig['subtitles_config']['principal_subtitle_color'][0],
+                $subtitlesConfig['subtitles_config']['principal_subtitle_color'][1],
+                $subtitlesConfig['subtitles_config']['principal_subtitle_color'][2]
+            );
+            
+            $pdfTemplate->Write(
+                5, 
+                $subtitlesConfig['subtitles_texts'][$localeKey]
+            );
+
             unset($subtitlesConfig['subtitles_texts'][$localeKey]);
         }
         
         $pdfTemplate->Ln(10);
 
+        //print remaining titles and subtitles for all languages if they exist
         foreach ($titlesConfig['titles_texts'] as $language => $title) {
-            $text = $title . '. ' . $subtitlesConfig['subtitles_texts'][$language];
+            $prefix = empty($prefixesConfig['prefixes_texts'][$language]) ? '' : $prefixesConfig['prefixes_texts'][$language] . ' ';
+            $subtitle = '. ' . $subtitlesConfig['subtitles_texts'][$language] ?? '';
+
+            $text = $prefix . $title . $subtitle;
             $font = $titlesConfig['titles_config']['font']; 
-            $pdfTemplate->SetFont($font['family'], $font['style'], $font['size']);
-            $pdfTemplate->SetTextColor($titlesConfig['titles_config']['text_color'][0], $titlesConfig['titles_config']['text_color'][1], $titlesConfig['titles_config']['text_color'][2]);
-            NoLinkableText::renderNoLinkableText($pdfTemplate, $text, $pdfTemplate->GetX(), $pdfTemplate->GetY(), $titlesConfig['titles_config']['text_color'], $font);
+
+            $pdfTemplate->SetFont(
+                $font['family'],
+                $font['style'], 
+                $font['size']
+            );
+
+            $pdfTemplate->SetTextColor(
+                $titlesConfig['titles_config']['text_color'][0], 
+                $titlesConfig['titles_config']['text_color'][1], 
+                $titlesConfig['titles_config']['text_color'][2]
+            );
+
+            NoLinkableText::renderNoLinkableText(
+                $pdfTemplate,
+                $text, 
+                $pdfTemplate->GetX(), 
+                $pdfTemplate->GetY(), 
+                $titlesConfig['titles_config']['text_color'], 
+                $font
+            );
+
             $pdfTemplate->Ln(3);
         }
 

--- a/src/JATSParser/PDF/Templates/TemplateOne/Components/TemplateBody.php
+++ b/src/JATSParser/PDF/Templates/TemplateOne/Components/TemplateBody.php
@@ -154,6 +154,7 @@ class TemplateBody extends GenericComponent {
             $this->pdfTemplate->GetY(),
             $this->config->getTitlesConfig(),
             $this->config->getSubtitlesConfig(),
+            $this->config->getPrefixesConfig(),
             $localeKey
         );
 


### PR DESCRIPTION
Ahora se procesan correctamente los prefijos en todos los idiomas cargados en OJS, lo cual anteriormente no se hacía.