### PR TITLE
fix footnotes links styles and country in authors metadata

### DIFF
--- a/src/JATSParser/PDF/PDFBodyHelper.php
+++ b/src/JATSParser/PDF/PDFBodyHelper.php
@@ -31,12 +31,18 @@ class PDFBodyHelper {
 		self::processFiguresCitations($dom, $xpath);
 		self::processTableCitations($dom, $xpath);
 		self::processBlockquotes($dom, $xpath); 
-		self::addHrefAttributes($xpath);
+		self::processHrefElements($xpath);
+		self::processExternalLinks($dom, $xpath);
 
 		// Remove redundant whitespaces before caption label
 		$modifiedHtmlString = $dom->saveHTML();
 		$modifiedHtmlString = preg_replace('/<caption>\s*/', '<br>' . '<caption>', $modifiedHtmlString);
 		$modifiedHtmlString = preg_replace('/<p class="caption">\s*/', '<p class="caption">', $modifiedHtmlString);
+
+		file_put_contents(
+			__DIR__ . '/htmlString.html',
+			$modifiedHtmlString
+		);
 
 		return $modifiedHtmlString;
 	}
@@ -194,10 +200,28 @@ class PDFBodyHelper {
 	 * @param \DOMDocument $dom The DOM document
 	 * @param \DOMXPath $xpath The XPath object for DOM traversal
 	 */
-	private static function addHrefAttributes(\DOMXPath $xpath): void {
+	private static function processHrefElements(\DOMXPath $xpath): void {
+		//process all links in the document(including urls - citations)
 		$refs = $xpath->evaluate('//a');
 		foreach ($refs as $ref) {
 			$ref->setAttribute('style', 'color: #0066CC; text-decoration: none;'); 
+		}
+	}
+
+	private static function processExternalLinks(\DOMDocument $dom, \DOMXPath $xpath): void {
+		// Process external links to ensure they are styled correctly and converted to <a> elements for a correct styling process in TCPDF
+		$externalLinks = $xpath->evaluate('//ext-link');
+		foreach ($externalLinks as $link) {
+			// Create a new <a> element with the link text
+			$a = $dom->createElement('a', $link->textContent);
+			// Copy the class attribute if it exists
+			if ($link->hasAttribute('xlink:href')) {
+				$a->setAttribute('href', $link->getAttribute('xlink:href'));
+			}
+			// Add the class attribute if it exists
+			$a->setAttribute('style', 'color: #0066CC; text-decoration: none;');
+			// Replace the <ext-link> element with the new <a> element
+			$link->parentNode->replaceChild($a, $link);
 		}
 	}
 

--- a/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/AuthorsData.php
+++ b/src/JATSParser/PDF/Templates/Renderers/GroupRenderer/AuthorsData.php
@@ -58,12 +58,13 @@ class AuthorsData {
                     // Affiliation with Country
                     if ($author->getAffiliation($localeKey)) {
                         $affiliationText = htmlspecialchars($author->getAffiliation($localeKey));
-                        
-                        // Append country if available
+                    
+                        /* // Append country if available -> NOT NEEDED
                         if ($author->getCountryLocalized($localeKey)) {
                             $country = htmlspecialchars($author->getCountryLocalized($localeKey));
                             $affiliationText .= ', ' . $country;
                         }
+                        */
                         
                         $pdfTemplate->SetFont(
                             $authorsConfig['authors_config']['affiliation_font']['family'], 

--- a/src/JATSParser/PDF/htmlString.html
+++ b/src/JATSParser/PDF/htmlString.html
@@ -1,0 +1,261 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN" "http://www.w3.org/TR/REC-html40/loose.dtd">
+<html><head>	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+</head>
+<body><h2 class="article-section-title">Background</h2>
+<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec ornare mattis feugiat. Nam metus mauris, egestas congue <a id="xref-6087106bfc0cc6209058c6a436c1b422" class="bibr" href="#parser_0" style="color: #0066CC; text-decoration: none;">[1]</a>odio quis, egestas laoreet justo (1). Aliquam erat volutpat. Curabitur at quam non diam interdum rhoncus. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus (Tomás Messineo, 20254e). Praesent non nisl vehicula justo consectetur porttitor non interdum ex. Nunc porta purus ante, eget faucibus ante tempor eget. Ut vitae commodo quam, non mattis odio. In ultrices risus eget pulvinar facilisis. Vivamus nec nisl libero (2). Etiam velit neque, ullamcorper id ornare in, pharetra vel magna (3–5). Ut vehicula pellentesque quam, et aliquam massa volutpat eget . Suspendisse potenti. Sed ultricies nibh eu felis consectetur pellentesque.</p>
+<p>In et tellus bibendum, fermentum massa id, mollis nisl. Vestibulum malesuada vehicula metus ac condimentum. Morbi quis massa aliquet turpis pharetra varius at eu sem. Phasellus sed pretium ligula, sed ultrices tellus. Donec aliquam sodales ligula dapibus vehicula. Mauris a eros in diam posuere iaculis quis vel ipsum. Duis iaculis condimentum lobortis. Donec non tristique ipsum, ut posuere massa . Morbi ante tellus, semper vitae justo a, consectetur accumsan nunc. Duis sed vulputate ante. Duis vel imperdiet neque. Vestibulum risus mauris, rhoncus id elementum a, ultrices eget sem. Mauris luctus dui at lectus interdum, non aliquet orci laoreet.</p>
+<p><b>Integer sed posuere enim.</b> Praesent interdum, nisl at porttitor auctor, magna justo semper tellus, quis molestie nunc turpis ut eros. Phasellus ultrices cons<a id="xref-4a2ef4ef899763818b050f7cef5f13df" class="fn" href="#footnote-48e5d6cd6a7159559666d414ea7ab62b" style="color: #0066CC; text-decoration: none;"><sup>1</sup></a> equat est a bibendum. Nam fermentum pretium erat vel varius. In auctor non risus eget laoreet. Aliquam ut elit id ante blandit eleifend laoreet egestas turpis. Etiam at felis eu justo faucibus accumsan. Praesent rhoncus in magna non sagittis. Ut molestie ex erat, quis venenatis eros vestibulum non. Proin eu pulvinar metus, nec dapibus ex. Aenean purus nunc, vulputate sit amet ligula nec, posuere vestibulum tortor. Aliquam est neque, tempus elementum pellentesque ut, gravida blandit justo. Mauris velit elit, scelerisque ac lorem a, vulputate pulvinar risus. Ut scelerisque vel <a class="JATSParser__link-external-link-c0abb857421e76bda9ae94a017f99f17" style="color: #0066CC; text-decoration: none;">https://github.com/</a> lectus vitae ornare<a id="xref-56ca1e297792bbfc43cc0fea5cc88657" class="fn" href="#footnote-f5f2120117242ccb5607f46636877fdf" style="color: #0066CC; text-decoration: none;"><sup>2</sup></a>.</p>
+<h2 class="article-section-title">Methods</h2>
+<h3 class="article-section-title">Study design</h3>
+<p><b>Nullam hendrerit condimentum tellus eu sagittis.</b> Suspendisse lacus felis, tincidunt eget feugiat non, tristique in augue. Cras pharetra quam sed sapien mattis volutpat. In placerat, orci a pharetra lacinia, dolor nunc pellentesque est, sed interdum mauris arcu quis purus. Curabitur convallis, sapien varius rutrum elementum, nunc ligula varius nisl, pulvinar lobortis leo sapien vitae turpis. <i>Maecenas luctus</i>, libero vestibulum rhoncus sodales, nunc nunc blandit massa, non finibus metus nulla vitae mauris. Quisque non vehicula ex. Cras mollis sit amet ante eu euismod. Ut cursus commodo sapien quis ornare. Vestibulum varius, ipsum quis pretium semper, dolor urna sagittis mauris, in dictum tellus lorem sit amet ipsum. Proin et mauris a erat interdum aliquam. Duis non ante ac nisl malesuada pretium. Cras et dignissim ipsum, sed iaculis nisi. <i>Donec ut tortor et metus</i> porttitor pharetra euismod non urna. Cras pharetra metus purus, a interdum sapien consequat et. Duis vitae sodales nisi.</p>
+<p><b>Nunc sit amet eleifend mi.</b> Praesent id iaculis risus. Aenean ac erat congue enim mattis mattis a vel est. Proin pulvinar non felis tristique efficitur. Aliquam venenatis eget nisi non scelerisque. Suspendisse vel lectus convallis velit congue rhoncus sagittis a sem. Mauris tincidunt molestie risus. Pellentesque accumsan egestas ex, sit amet fermentum lorem mollis sollicitudin. Vestibulum quis dapibus nisi. Proin pulvinar vitae arcu a malesuada. Suspendisse ultrices, dolor non efficitur semper, sem orci volutpat nibh, in fermentum ipsum tortor eget urna. Integer vel eros sed lorem consectetur pellentesque. Nullam ac massa vitae urna iaculis scelerisque at eu massa. Fusce dignissim ex id nibh pulvinar rutrum. Pellentesque quis vulputate quam.</p>
+<p><b>Sed sed accumsan lectus.</b> Praesent sit amet enim id mi iaculis congue. Proin fermentum mollis pretium. Maecenas tempor leo ut faucibus convallis. Sed placerat fermentum consectetur. Nunc ante nulla, lobortis eget ex at, accumsan cursus tellus. Curabitur blandit, velit at semper aliquet, neque magna mollis elit, non tincidunt dui quam at magna. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Morbi porttitor tincidunt urna, eu blandit risus gravida ut. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus mattis orci varius, blandit felis ac, tempus nulla. Nulla semper auctor egestas. Curabitur sodales quam id imperdiet finibus.</p>
+<h3 class="article-section-title">Sample</h3>
+<p>Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. </p>
+<ol>
+  <li>
+            Ut scelerisque turpis nec lorem cursus, vestibulum venenatis felis convallis. 
+          </li>
+  <li>
+            Vivamus metus tellus, cursus nec ex sollicitudin, volutpat lobortis nibh. 
+          </li>
+  <li>
+            Maecenas consequat, quam a sodales porttitor, purus ipsum placerat mi, sed efficitur lectus risus eu nulla. 
+            <ul><li>
+                Phasellus egestas finibus tincidunt. Nullam euismod aliquam purus a egestas. 
+              </li><li>
+                Nunc laoreet quam metus, vel faucibus turpis laoreet vitae. 
+              </li><li>
+                Mauris eleifend ut sapien eu scelerisque. 
+              </li><li>
+                Nulla imperdiet elit quis leo vehicula iaculis. 
+              </li><li>
+                Curabitur a nunc auctor, semper ex a, ornare tortor. Suspendisse eu nisl eu ex egestas ultricies ut quis purus. 
+              </li></ul>
+          </li>
+</ol>
+<ul></ul>
+<p>Suspendisse eu nisl eu ex egestas ultricies ut quis purus. Donec dignissim, nibh id fermentum eleifend, arcu mi pharetra nisl, in dignissim diam tellus at leo. Nam a erat ut nibh consequat pharetra in ultrices odio. Nulla viverra, libero eget efficitur efficitur, ante ligula imperdiet tortor, eu cursus augue quam sed augue.</p>
+<h3 class="article-section-title">Measures</h3>
+<p>Donec iaculis at ligula ac cursus. Praesent eu odio sed neque sollicitudin efficitur. Aenean ac felis ut sem luctus imperdiet nec quis massa. Suspendisse aliquam risus et posuere iaculis. Aliquam quis euismod nisi. Nunc finibus lorem eu diam sagittis, et tincidunt nibh auctor. Praesent imperdiet nisi et ligula ornare bibendum. Sed aliquam, nulla eu venenatis placerat, sem dolor volutpat ante, sed tincidunt tortor ante venenatis turpis. Nam molestie euismod enim, vitae scelerisque neque aliquam quis. Ut ut ornare orci. Duis tempus est ut diam venenatis tristique. Fusce egestas consequat felis, a venenatis urna aliquet vel. Ut leo nisi, ullamcorper vitae purus vitae, commodo fermentum nisl. Morbi molestie vulputate justo, et scelerisque tellus bibendum et. Sed maximus eros lobortis augue vestibulum tristique.</p>
+<h3 class="article-section-title">Statistical analysis</h3>
+<p>Fusce ut nibh orci. <b>Phasellus libero urna</b>, <b><i>suscipit non</i></b> leo eu, rhoncus finibus turpis. Aliquam ultricies, ipsum eget bibendum elementum, metus purus condimentum neque, vel pharetra sapien arcu nec diam. Donec vel tempor enim. Quisque fermentum massa ac augue porta, et ullamcorper risus vestibulum. Praesent efficitur massa mi, sed bibendum nulla aliquam ut. Phasellus in purus a augue mattis venenatis quis eu felis. Donec a leo vel arcu vestibulum consectetur. Duis a feugiat risus. Maecenas ornare augue eget lobortis gravida. Nullam lectus augue, venenatis sit amet nibh tristique, ullamcorper sollicitudin purus. Aliquam quis fermentum leo.</p>
+<h3 class="article-section-title">Treatment algorithm</h3>
+<p>Nam sagittis scelerisque tortor, at pulvinar dui. Cras tellus mi, aliquet eget pellentesque id, feugiat sit amet ligula. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Sed feugiat ligula vitae diam laoreet aliquet (See ). Aenean tristique vulputate enim, quis interdum leo volutpat at. </p>
+<figure id="fig1">
+  <div class="figure">
+    <img src="image1.png">
+  </div>
+  <p class="caption"><span class="title">Illustration 1: Pellentesque ac ligula facilisis, eleifend magna sed, vehicula libero; donec lectus est, fermentum vel sapien in, mollis finibus purus. </span>
+    <span class="notes"></span>
+  </p>
+</figure>
+<p>Proin condimentum quam vel aliquam eleifend. Donec vehicula, leo sed feugiat euismod, mauris nunc pretium dui, ac dignissim dui neque eu augue. Pellentesque dolor sem, sollicitudin in orci eget, condimentum pharetra eros. Curabitur aliquam accumsan facilisis. Donec ullamcorper, eros at vehicula suscipit, nisi elit ultrices lectus, sit amet viverra eros metus eu mauris. Vestibulum quis consectetur enim. Aenean ornare nisi ut erat venenatis lobortis. Donec mollis placerat ipsum ut porttitor. Maecenas vitae faucibus tellus. Proin scelerisque mattis consectetur.</p>
+<h2 class="article-section-title">Results</h2>
+<h3 class="article-section-title">Primary outcome</h3>
+<p>Quisque ante ante, varius nec tortor at, blandit fermentum sapien. Nam at placerat ante. Sed cursus erat eget dui finibus suscipit in . Duis at est facilisis, maximus diam ac, viverra nisl. Aenean tristique, leo id vestibulum lacinia, ligula massa congue felis, vel facilisis quam erat sed turpis. Quisque malesuada, lacus eu maximus ornare, enim lacus porttitor nunc, nec maximus dui dolor sit amet magna. Donec tincidunt dolor vulputate, ultrices arcu vel, tristique arcu. Cras aliquet euismod feugiat. Fusce auctor ac leo sed scelerisque. Fusce volutpat ipsum ac feugiat suscipit. Vestibulum elit sem, luctus quis neque at, fermentum porta dolor. Donec venenatis tempus tempus. Quisque faucibus, nisl eu blandit laoreet, mauris ex dictum nisl, at bibendum ex risus sed nulla. Nunc eget porta metus. Duis ut neque sed nisl dapibus aliquam. Cras molestie sed libero vitae lacinia.</p>
+<p></p>
+<table id="tbl1" border="1" cellpadding="2">
+  <tbody>
+    <tr>
+      <td colspan="1" rowspan="1">Measure</td>
+      <td colspan="1" rowspan="1">Control group</td>
+      <td colspan="1" rowspan="1">Active treatment</td>
+      <td colspan="1" rowspan="1">Total</td>
+    </tr>
+    <tr>
+      <td colspan="4" rowspan="1" align="center">Males</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">N</td>
+      <td colspan="1" rowspan="1">33</td>
+      <td colspan="1" rowspan="1">32</td>
+      <td colspan="1" rowspan="1">65</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">% among groups</td>
+      <td colspan="1" rowspan="1">50.77%</td>
+      <td colspan="1" rowspan="1">49.23%</td>
+      <td colspan="1" rowspan="1">100%</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">% among general sample</td>
+      <td colspan="1" rowspan="1">61.11%</td>
+      <td colspan="1" rowspan="1">59.26%</td>
+      <td colspan="1" rowspan="1">60.19%</td>
+    </tr>
+    <tr>
+      <td colspan="4" rowspan="1" align="center">Female</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">N</td>
+      <td colspan="1" rowspan="1">21</td>
+      <td colspan="1" rowspan="1">22</td>
+      <td colspan="1" rowspan="1">43</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">% among groups</td>
+      <td colspan="1" rowspan="1">48.84%</td>
+      <td colspan="1" rowspan="1">51.16%</td>
+      <td colspan="1" rowspan="1">100%</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">% among general sample</td>
+      <td colspan="1" rowspan="1">38.89%</td>
+      <td colspan="1" rowspan="1">40.74%</td>
+      <td colspan="1" rowspan="1">39.81%</td>
+    </tr>
+  </tbody>
+  
+</table><div class="caption"><br><caption><span class="label">Tabla 1 </span>
+    <span class="title">Table 1: Ynteger enim massa, tempor ut nulla ac, porttitor auctor justo phasellus lacinia vel massa ac tempus in id interdum arcu. </span>
+    <span class="notes"></span>
+  </caption></div>
+<p>Aliquam commodo, sapien a gravida viverra, neque arcu lacinia elit, at varius sem erat id massa. Praesent magna odio, dignissim vel sollicitudin non, posuere in velit. Aliquam dapibus neque tellus, et venenatis sem gravida ac. Etiam vel justo a tellus aliquam dapibus. Donec tristique at ligula vel condimentum. Sed eget arcu ac ex facilisis feugiat. Sed congue nisl et ultricies fringilla. Nunc eu dolor ac arcu cursus posuere.</p>
+<h3 class="article-section-title">Secondary outcomes</h3>
+<h4 class="article-section-title">Therapeutic criteria</h4>
+<p>Duis sollicitudin vitae velit at molestie. Sed nibh augue, accumsan ut arcu id, porttitor malesuada mauris. Curabitur vehicula eu dolor a blandit. Sed ut venenatis tortor. Donec tincidunt nibh vel nulla vulputate, nec iaculis velit vestibulum. </p>
+<p>Fusce tempus laoreet dolor nec pretium. Sed lacinia ullamcorper fermentum:</p>
+<ol>
+  <li>
+              Maecenas in <b>porta</b> dolor, ut sodales nulla. 
+            </li>
+  <li>
+              Aenean eget cursus est. 
+            </li>
+  <li>
+              Nulla ac efficitur sapien, porta euismod metus. 
+            </li>
+  <li>
+              Mauris fringilla <b><i>ut enim</i></b> vel tincidunt. 
+            </li>
+  <li>
+              Duis nunc dolor, mattis vitae tincidunt sit amet, efficitur eu mauris. 
+            </li>
+  <li>
+              Etiam at mauris vel ligula finibus commodo ut nec felis. 
+            </li>
+  <li>
+              <i>Praesent</i> iaculis nibh vel velit ultrices, tempor pulvinar odio ultrices. Aenean metus nibh, convallis nec ultricies vel, elementum ut eros.
+            </li>
+</ol>
+<p>Aliquam pharetra aliquet nisi et cursus. Praesent vehicula risus eu dolor pretium blandit. Praesent pretium molestie tempor. Etiam porttitor, eros sagittis lobortis convallis, justo turpis porttitor erat, eget malesuada magna erat congue lectus.</p>
+<h4 class="article-section-title">Symptoms intensity</h4>
+<p>Aenean et condimentum augue. Ut placerat velit sem, vel dapibus purus ullamcorper sollicitudin. Donec vel semper odio. Cras metus justo, feugiat eget pellentesque id, porta eu augue. Cras tempor maximus est, gravida volutpat elit rutrum quis. Pellentesque nec rutrum metus. Donec lacinia efficitur mauris placerat tempus. Phasellus in magna nec massa tincidunt condimentum in ut mi. Nam neque ex, tempus non odio eu, mollis lobortis nibh. Integer ex orci, consectetur in molestie eget, vulputate eget ligula. Praesent faucibus ut tortor sodales facilisis. Pellentesque a risus augue. In pretium commodo nisl, in hendrerit neque. Aliquam viverra tincidunt tempus (see ).</p>
+<table id="tbl2" border="1" cellpadding="2">
+  <tbody>
+    <tr>
+      <td colspan="1" rowspan="1">Measure</td>
+      <td colspan="1" rowspan="1">N</td>
+      <td colspan="1" rowspan="1">Mean</td>
+      <td colspan="1" rowspan="1">SD</td>
+      <td colspan="1" rowspan="1">95% CI</td>
+      <td colspan="1" rowspan="1">Max</td>
+      <td colspan="1" rowspan="1">Min</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">Criterion B</td>
+      <td colspan="1" rowspan="5">108</td>
+      <td colspan="1" rowspan="1">12.00</td>
+      <td colspan="1" rowspan="1">2.41</td>
+      <td colspan="1" rowspan="1">11.54-12.46</td>
+      <td colspan="1" rowspan="1">5</td>
+      <td colspan="1" rowspan="1">19</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">Criterion C</td>
+      <td colspan="1" rowspan="1">5.37</td>
+      <td colspan="1" rowspan="1">1.13</td>
+      <td colspan="1" rowspan="1">5.16-5.58</td>
+      <td colspan="1" rowspan="1">3</td>
+      <td colspan="1" rowspan="1">8</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">Criterion D</td>
+      <td colspan="1" rowspan="1">16.48</td>
+      <td colspan="1" rowspan="1">3.33</td>
+      <td colspan="1" rowspan="1">15.85-17.12</td>
+      <td colspan="1" rowspan="1">10</td>
+      <td colspan="1" rowspan="1">23</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">Criterion E</td>
+      <td colspan="1" rowspan="1">13.09</td>
+      <td colspan="1" rowspan="1">3.07</td>
+      <td colspan="1" rowspan="1">12.51-13.68</td>
+      <td colspan="1" rowspan="1">6</td>
+      <td colspan="1" rowspan="1">20</td>
+    </tr>
+    <tr>
+      <td colspan="1" rowspan="1">Total (B+C+D+E)</td>
+      <td colspan="1" rowspan="1">46.93</td>
+      <td colspan="1" rowspan="1">8.44</td>
+      <td colspan="1" rowspan="1">45.32-48.54</td>
+      <td colspan="1" rowspan="1">26</td>
+      <td colspan="1" rowspan="1">68</td>
+    </tr>
+  </tbody>
+  
+</table><div class="caption"><br><caption><span class="label">Tabla 2 </span>
+    <span class="title">Table 2: Aenean ut purus aliquet, bibendum orci et, gravida odio. </span>
+    <span class="notes"></span>
+  </caption></div>
+<h2 class="article-section-title">Discussion</h2>
+<p>Duis ut cursus ligula, sit amet ultrices augue. Praesent commodo orci a placerat convallis. Curabitur interdum purus metus, sit amet porta ligula pretium sed. Mauris non lectus est. Nunc sodales euismod placerat. Donec viverra, ipsum a tempus suscipit, velit ante fermentum nibh, ac tincidunt lorem lorem sed orci. Etiam risus libero, interdum ut ante nec, bibendum placerat eros. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos. In sed vehicula ante. Pellentesque vehicula tristique nisi, quis commodo erat rhoncus sed. Quisque porta pellentesque lacus, eu bibendum lorem mattis at. Aenean ut purus aliquet, bibendum orci et, gravida odio.</p>
+<p>Quisque rutrum tortor vitae ante fermentum interdum. Vivamus sollicitudin sodales turpis, a fermentum felis ullamcorper non. Duis nec justo sit amet ligula malesuada imperdiet. Cras id ex vulputate, ornare felis vel, fringilla elit. Vivamus dignissim metus eget magna porttitor tincidunt. Sed dignissim nunc sit amet hendrerit tristique. Nullam ante nisl, porta egestas nisl in, egestas consequat ligula. Cras tristique elementum tellus, non vehicula risus congue at. Nulla gravida dolor libero, eget cursus magna consequat quis. Etiam gravida nisi leo, eu aliquet risus hendrerit eu.</p>
+<p>Pellentesque aliquet, nisl in venenatis maximus, quam lacus pulvinar elit, ac tincidunt nisl tortor non nisi. Aenean eget rhoncus tellus, eu euismod urna. Suspendisse et feugiat risus, sed pretium tortor . Vestibulum ac magna in mauris pretium tincidunt. Suspendisse velit dolor, sollicitudin tristique justo eu, luctus rutrum leo. Proin porta lacus sed massa molestie, et tincidunt nunc euismod. Ut id porta massa, eget laoreet leo.</p>
+<h2 class="article-section-title">Conclusion</h2>
+<p>Cras vitae urna turpis. Nam vel velit placerat, luctus sapien non, ornare odio. Integer bibendum imperdiet tellus sed tincidunt. Sed volutpat id urna in malesuada. Etiam ultricies sapien elit, non finibus odio efficitur at. Aenean non elit a nulla sollicitudin auctor. Suspendisse vitae mi pellentesque, pellentesque erat in, facilisis velit. Duis commodo commodo tristique. Nam eu tincidunt tortor. Maecenas id gravida est, eget lacinia nisl. Aliquam purus arcu, rutrum nec feugiat a, malesuada non leo. Nulla sollicitudin, enim at rhoncus commodo, orci libero luctus purus, id viverra lacus nisl non nibh.</p>
+<h2 class="article-section-title">References</h2>
+
+
+<div class="references-section" style="margin-top: 3em; border-top: 1px solid #ddd; padding-top: 1em;"><h2>Referencias</h2><div id="references" class="citation-list" data-style="apa" style="margin-top: 2em;">
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Abad Castelló, M., &amp; Álvarez Baz, A. (2021). Aprendizaje basado en datos y combinaciones léxicas: una propuesta didáctica con cuasisinónimos. <i>MLS Educational Research</i>, <i>2</i>(5), 88-104. <span class="citation-url" style="color: #31849b; word-wrap: break-word;">https://doi.org/10.29314/mlser.v5i2.562</span></li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Aikhenwald, A. (2012). The essence of mirativity. <i>Linguistic Typology</i>, <i>3</i>(16), 435-485. <span class="citation-url" style="color: #31849b; word-wrap: break-word;">https://doi.org/10.1515/lity-2012-0017</span></li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Angelina Oliveira, A. (2024). <i>Producciones escritas de angloparlantes en el marco de exámenes CELU</i>.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Call, J., &amp; Carpenter, M. (2002). Three sources of information in social learning. En K. Dautenhahn &amp; C. Nehaniv (Eds.), <i>Imitation in animals and artifacts</i>. Cambridge, USA: MIT Press.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Fedigan, L. M., &amp; Strum, S. (1999). A brief history of primate studies: national traditions, disciplinary origins, and stages in North American field research. En P. Dolhinow &amp; A. Fuentes (Eds.), <i>The non-human primates.</i> Mountain View USA Mayfield Publishing Company.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">González Vázquez, M. (1998). <i>La polisemia de ’poder’ en e/le: acerca de la pertinencia comunicativa de la posibilidad lateral y bilateral</i>.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Grice, P. (1991). Lógica de la conversación. En L. Valdées Villanueva (Ed.), <i>La búsqueda del Significado</i>. Tecnos.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Hoye, L. (2008). Evidentiality in discourse: A pragmatic and empirical account. En J. Romero (Ed.), <i>Pragmatics and corpus linguistics</i>. Mouton de Gruyter.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Matsuzawa, T., &amp; Yamakoshi, G. (1996). Comparison of chimpanzee material culture between Bossou and Nimba, West Africa. En A. Russon, K. Bard, &amp; S. Parkers (Eds.), <i>Reaching into thought</i>. United Kingdom Cambridge University Press.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Sperber, D., &amp; Wilson, D. (1991). Sobre la definición de Relevancia. En L. Valdés Villanueva (Ed.), <i>La búsqueda del significado</i>. Tecnos.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Vatrican, A. (2015). La modalidad en la gramática: la capacidad en las construcciones saber y poder infinitivo. <i>Revista Española de Lingüística</i>, <i>2</i>(45), 115-141.</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Hola. Esto es una referencia mal escirita (2023). --- ERRORS FOUND IN THESE SECTIONS: "Title. "</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">-sawda-w2 --- ERRORS FOUND IN THESE SECTIONS: "Author. Date. Title. "</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">21.sc12. --- ERRORS FOUND IN THESE SECTIONS: "Author. Date. Title. "</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Vatrican, A. (2015). la modalidad en la gramática: la capacidad en las construcciones saber y poder infinitivo. Revista Española de Lingüística, 45(2), 115–141. --- ERRORS FOUND IN THESE SECTIONS: "Title. "</li><br>
+	<li class="citation-item" style="margin-left: 0; padding-left: 7em; margin-bottom: 2.5em; line-height: 1.1; text-align: left; padding-bottom: 0.5em;">Aikhenwald, A (20s22). the. Linguistic Typology, 16(3), 435-485.  --- ERRORS FOUND IN THESE SECTIONS: "Date. Title. "</li><br>
+</div></div>
+<div class="footnotes-container" style="margin-top: 3em; border-top: 1px solid #ddd; padding-top: 1em;"><h2>Notas</h2><div class="footnote-item" id="fn-footnote-48e5d6cd6a7159559666d414ea7ab62b" style="display: flex; flex-direction: row; margin-bottom: 1em; font-size: 1.05em; align-items: flex-start;"><span class="footnote-label" style="display: inline-block; color: #31849b; font-weight: bold; margin-right: 0.8em; min-width: 1.5em; text-align: left;">1 </span><span class="footnote-content" style="display: inline-block; flex: 1; text-align: left;">Footnote de prueba</span></div><div class="footnote-item" id="fn-footnote-f5f2120117242ccb5607f46636877fdf" style="display: flex; flex-direction: row; margin-bottom: 1em; font-size: 1.05em; align-items: flex-start;"><span class="footnote-label" style="display: inline-block; color: #31849b; font-weight: bold; margin-right: 0.8em; min-width: 1.5em; text-align: left;">2 </span><span class="footnote-content" style="display: inline-block; flex: 1; text-align: left;">Segunda Footnote de prueba <a style="color: #0066CC; text-decoration: none;">https://github.com/</a></span></div></div>
+<style>
+span.label {
+	font-size: 10px;
+	font-weight: bold;
+}
+
+span.title {
+	font-size: 10px;
+	font-style: italic;
+}
+
+span.notes, p.caption, table {
+	font-size: 10px;
+}
+
+div.caption {
+	line-height: 90%;
+}
+
+a {
+	color: #530101;
+}
+
+th {
+	background-color: #F8F8FF;
+}
+
+.caption br {
+	line-height: 50%;
+}
+</style></body></html>


### PR DESCRIPTION
Se solucionaron problemas con respecto a los estilos en las footnotes. Lo que se hizo fue reemplazar los <ext-link> por <a> en todo el html, ya que por lo visto TCPDF no soporta estilos en los external links y sí en los anchors. 

También se quitó el metadato correspondiente al país en el renderer AuthorsData, ahora solo se imprime la afiliación.